### PR TITLE
Adds mailer to mail participants discord invite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /node_modules
 
 .DS_Store
+
+.env

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A simple node.js script to onboard hackathon registrants onto discord via CSV.
 
 ### Content source
 
-The script uses the `resources/sample.csv` as the source of truth when preforming preforming discord onboardings. 
+The script uses the `resources/hackers.csv` as the source of truth when preforming preforming discord onboardings. 
 
 ### Command Line Options
 
@@ -33,7 +33,7 @@ The script runs entirely through the command line and can be run with the follow
 ### How to run the script
 
 0. Open up a terminal and traverse to the project root i.e. `cd some/path/to/web3con-hackathon-discord-onboarder`
-1. Replace the content of `resources/sample.csv` with the data of your liking,
+1. Replace the content of `resources/hackers.csv` with the data of your liking,
 2. Run `ts-node onboarder.ts -d true` to run the script in `dryrun` mode to observe how your requests will look like without actually uploading.
 3. Observe the `logs/service.log` file to see if your data looks like you expect it to
 4. Assuming you are satisfied with your dryrun and/or testweave uploads you can now upload to the Arweave mainnet via `ts-node onboarder.ts -d false -t false`

--- a/onboarder.ts
+++ b/onboarder.ts
@@ -1,6 +1,9 @@
 import { Command } from 'commander';
 import { parseStream } from "fast-csv"
 import { createReadStream } from "fs";
+import { MailMeta } from './src/types/mailer-types';
+import { DISCORD_INVITE } from './src/utils/constants';
+import mail from './src/mailer/mailer';
 import winston from "winston";
 
 const LOGGER = winston.createLogger({
@@ -15,16 +18,27 @@ const program = new Command()
 
 const dry_run = program.parse().opts().dryrun;
 
-const createUploadRequestFromRow = (row: any, headers: string[]) => {
-  return [];
+const createMailMetaFromRow = (row: any) => {
+  return {
+    to: row["email"],
+    subject: "Web3Con 2022 Hackathon Discord invite",
+    message: `Hi ${row["discord_handle"]}, thank you for joining the Web3Con 2022 hackathon.  Please use the link below to join the hackathon discord server`,
+    inviteLinkHTML: `<h2>Discord invite link: </h2><p>${DISCORD_INVITE}</p>`
+  } as MailMeta;
 }
 
-const readAndUploadDataFromCSV = async () => {
+const mailParticipants = async (mailingList: MailMeta[]) => {
+  for (let i = 0; i < mailingList.length; i++) {
+    await mail(mailingList[i])
+  }
+}
+
+const readAndProcessDataFromCSV = async () => {
   LOGGER.info(`[Script configuration overview] Dry_Run=${dry_run}`);
 
-  let requests: any[] = [];
+  let mailingList: any[] = [];
 
-  const stream = createReadStream('resources/sample.csv');
+  const stream = createReadStream('resources/hackers.csv');
 
   // The headers of the CSV act as our keys for the tags we attach to the data we upload
   let headers = [] as string[];
@@ -36,26 +50,27 @@ const readAndUploadDataFromCSV = async () => {
     })
     .on('error', error => LOGGER.error(`[Error parsing CSV] Error=${error}`))
     .on('data', ((row) => {
-      const uploadRequest = createUploadRequestFromRow(row, headers);
+      const mailMeta = createMailMetaFromRow(row);
 
       if (dry_run === "true") {
         LOGGER.info(`[Row processed] row=${JSON.stringify(row)}`);
-        LOGGER.info(`[Upload Request] ${JSON.stringify(uploadRequest)}`);
+        LOGGER.info(`[Mail Preview] ${JSON.stringify(mailMeta)}`);
       }
 
-      requests.push(uploadRequest);
+      mailingList.push(mailMeta);
 
     }))
     .on('end', async (rowCount: number) => {
       LOGGER.info(`[CSV processing completed] Parsed ${rowCount} rows`);
 
-      if(dry_run === "true") {
-        console.log("dry run")
+      if (dry_run === "true") {
+        console.log("dry run complete - check the service.log to ")
       } else {
-        console.log("preform upload")
+        console.log("--- Begin mailing process ---")
+        mailParticipants(mailingList);
       }
 
     });
 }
 
-readAndUploadDataFromCSV();
+readAndProcessDataFromCSV();

--- a/onboarder.ts
+++ b/onboarder.ts
@@ -22,14 +22,14 @@ const createMailMetaFromRow = (row: any) => {
   return {
     to: row["email"],
     subject: "Web3Con 2022 Hackathon Discord invite",
-    message: `Hi ${row["discord_handle"]}, thank you for joining the Web3Con 2022 hackathon.  Please use the link below to join the hackathon discord server`,
-    inviteLinkHTML: `<h2>Discord invite link: </h2><p>${DISCORD_INVITE}</p>`
+    message: `Hi ${row["discord_handle"]}, thank you for joining the Web3Con 2022 hackathon!  Please use the link below to join the Web3Con discord server:`,
+    inviteLinkHTML: `<div><a href="${DISCORD_INVITE}">${DISCORD_INVITE}</a></div>`
   } as MailMeta;
 }
 
 const mailParticipants = async (mailingList: MailMeta[]) => {
   for (let i = 0; i < mailingList.length; i++) {
-    await mail(mailingList[i])
+    await mail(mailingList[i]);
   }
 }
 
@@ -39,8 +39,6 @@ const readAndProcessDataFromCSV = async () => {
   let mailingList: any[] = [];
 
   const stream = createReadStream('resources/hackers.csv');
-
-  // The headers of the CSV act as our keys for the tags we attach to the data we upload
   let headers = [] as string[];
 
   parseStream(stream, { headers: true, ignoreEmpty: true })
@@ -64,12 +62,11 @@ const readAndProcessDataFromCSV = async () => {
       LOGGER.info(`[CSV processing completed] Parsed ${rowCount} rows`);
 
       if (dry_run === "true") {
-        console.log("dry run complete - check the service.log to ")
+        LOGGER.info("dry run complete - check the service.log to view the results ")
       } else {
-        console.log("--- Begin mailing process ---")
+        LOGGER.info("--- Begin Mailing Process ---")
         mailParticipants(mailingList);
       }
-
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -9,11 +9,15 @@
   "author": "@narbs91",
   "license": "MIT",
   "dependencies": {
+    "@discordjs/rest": "^0.3.0",
     "@types/node": "^16.10.3",
+    "@types/nodemailer": "^6.4.4",
     "commander": "^8.2.0",
+    "discord-api-types": "^0.26.1",
     "discord.js": "^13.6.0",
     "express": "^4.17.1",
     "fast-csv": "^4.3.6",
+    "nodemailer": "^6.7.2",
     "ts-node": "10.3.0",
     "winston": "^3.3.3"
   },

--- a/resources/hackers.csv
+++ b/resources/hackers.csv
@@ -1,0 +1,3 @@
+discord_handle,email
+someone,somewhere@gmail.com
+someone,somewhereelse@gmail.com

--- a/resources/sample.csv
+++ b/resources/sample.csv
@@ -1,2 +1,0 @@
-discord_handle
-abc123

--- a/src/mailer/mailer.ts
+++ b/src/mailer/mailer.ts
@@ -1,5 +1,13 @@
 import nodemailer from "nodemailer";
 import { MailMeta } from "../types/mailer-types";
+import winston from "winston";
+
+const LOGGER = winston.createLogger({
+    transports: [
+      new winston.transports.Console(),
+      new winston.transports.File({ filename: './logs/service.log' })
+    ]
+  });
 
 const mail = async (options: MailMeta) => {
 
@@ -36,11 +44,11 @@ const mail = async (options: MailMeta) => {
 
     transporter.sendMail(mailOptions, (error: any, info: any) => {
         if (error) {
-            console.log(`[error sending mail] to=${mailOptions.to} error=${error}`)
+            LOGGER.error(`[Error sending mail] from=${mailOptions.from}, to=${mailOptions.to}, error=${error}`)
         } else {
-            console.log(`Email sent: to=${mailOptions.to}  info=${info.response}`);
+            LOGGER.info(`[Email sent] from=${mailOptions.from}, to=${mailOptions.to},  info=${info.response}`);
             //Uncomment for testing
-            //console.log("Preview URL: %s", nodemailer.getTestMessageUrl(info));
+            //LOGGER.info(`Preview URL: ${nodemailer.getTestMessageUrl(info)}`);
         }
     });
 }

--- a/src/mailer/mailer.ts
+++ b/src/mailer/mailer.ts
@@ -1,0 +1,48 @@
+import nodemailer from "nodemailer";
+import { MailMeta } from "../types/mailer-types";
+
+const mail = async (options: MailMeta) => {
+
+    // Uncomment when testing
+    // let testAccount = await nodemailer.createTestAccount();
+
+    // let transporter = nodemailer.createTransport({
+    //     host: "smtp.ethereal.email",
+    //     port: 587,
+    //     secure: false, // true for 465, false for other ports
+    //     auth: {
+    //         user: testAccount.user, // generated ethereal user
+    //         pass: testAccount.pass, // generated ethereal password
+    //     },
+    // });
+
+    const FROM_ADDRESS = "aRealEmail@gmail.com";
+
+    const transporter = nodemailer.createTransport({
+        service: 'gmail',
+        auth: {
+          user: FROM_ADDRESS,
+          pass: process.env.EMAIL_PASSWORD
+        }
+      });
+
+    const mailOptions = {
+        from: FROM_ADDRESS,
+        to: options.to,
+        subject: options.subject,
+        text: options.message,
+        html: options.inviteLinkHTML
+    };
+
+    transporter.sendMail(mailOptions, (error: any, info: any) => {
+        if (error) {
+            console.log(`[error sending mail] to=${mailOptions.to} error=${error}`)
+        } else {
+            console.log(`Email sent: to=${mailOptions.to}  info=${info.response}`);
+            //Uncomment for testing
+            //console.log("Preview URL: %s", nodemailer.getTestMessageUrl(info));
+        }
+    });
+}
+
+export default mail;

--- a/src/types/mailer-types.ts
+++ b/src/types/mailer-types.ts
@@ -1,0 +1,6 @@
+export type MailMeta = {
+    to: string,
+    subject: string,
+    message: string,
+    inviteLinkHTML: string
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const DISCORD_ENDPOINT = "https://discord.com/api";
+export const DISCORD_INVITE="add invite here";

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,2 @@
 export const DISCORD_ENDPOINT = "https://discord.com/api";
-export const DISCORD_INVITE="add invite here";
+export const DISCORD_INVITE="https://www.discord.com";

--- a/yarn.lock
+++ b/yarn.lock
@@ -54,6 +54,19 @@
   resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.4.0.tgz#b6488286a1cc7b41b644d7e6086f25a1c1e6f837"
   integrity sha512-zmjq+l/rV35kE6zRrwe8BHqV78JvIh2ybJeZavBi5NySjWXqN3hmmAKg7kYMMXSeiWtSsMoZ/+MQi0DiQWy2lw==
 
+"@discordjs/rest@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/rest/-/rest-0.3.0.tgz#89e06a42b168c91598891d6bf860353e28fba5d2"
+  integrity sha512-F9aeP3odlAlllM1ciBZLdd+adiAyBj4VaZBejj4UMj4afE2wfCkNTGvYYiRxrXUE9fN7e/BuDP2ePl0tVA2m7Q==
+  dependencies:
+    "@discordjs/collection" "^0.4.0"
+    "@sapphire/async-queue" "^1.1.9"
+    "@sapphire/snowflake" "^3.0.1"
+    discord-api-types "^0.26.1"
+    form-data "^4.0.0"
+    node-fetch "^2.6.5"
+    tslib "^2.3.1"
+
 "@eslint/eslintrc@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.0.2.tgz#6044884f7f93c4ecc2d1694c7486cce91ef8f746"
@@ -146,6 +159,11 @@
   resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.2.0.tgz#7a56afd318101d338433d7180ebd6af349243268"
   integrity sha512-O5ND5Ljpef86X5oy8zXorQ754TMjWALcPSAgPBu4+76HLtDTrNoDyzU2uGE2G4A8Wv51u0MXHzGQ0WZ4GMtpIw==
 
+"@sapphire/snowflake@^3.0.1":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.1.0.tgz#1c2d9781d3b1de0bcb02b7079898947ce754d394"
+  integrity sha512-K+OiqXSx4clIaXcoaghrCV56zsm3bZZ5SBpgJkgvAKegFFdETMntHviUfypjt8xVleIuDaNyQA4APOIl3BMcxg==
+
 "@sindresorhus/is@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.4.0.tgz#e277e5bdbdf7cb1e20d320f02f5e2ed113cd3185"
@@ -198,6 +216,13 @@
   version "16.10.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
   integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
+
+"@types/nodemailer@^6.4.4":
+  version "6.4.4"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.4.tgz#c265f7e7a51df587597b3a49a023acaf0c741f4b"
+  integrity sha512-Ksw4t7iliXeYGvIQcSIgWQ5BLuC/mljIEbjf615svhZL10PE9t+ei8O9gDaD3FPCasUJn9KTLwz2JFJyiiyuqw==
+  dependencies:
+    "@types/node" "*"
 
 "@types/ws@^8.2.2":
   version "8.2.2"
@@ -632,7 +657,7 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-api-types@^0.26.0:
+discord-api-types@^0.26.0, discord-api-types@^0.26.1:
   version "0.26.1"
   resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.26.1.tgz#726f766ddc37d60da95740991d22cb6ef2ed787b"
   integrity sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==
@@ -1725,12 +1750,17 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.6.5:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+nodemailer@^6.7.2:
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.7.2.tgz#44b2ad5f7ed71b7067f7a21c4fedabaec62b85e0"
+  integrity sha512-Dz7zVwlef4k5R71fdmxwR8Q39fiboGbu3xgswkzGwczUfjp873rVxt1O46+Fh0j1ORnAC6L9+heI8uUpO6DT7Q==
 
 normalize-package-data@^2.3.2:
   version "2.5.0"


### PR DESCRIPTION


### What does it do?

- Adding this mailing method as a fallback method to passing out the discord invites to registrants of the web3con hackathon
- onboarded nodemailer to handle mailing
- added mailMeta type to house domain representation of a mail object
- changed sample.csv to hacker.csv and added email as a field in the row

### Any helpful background information?

We need a way to pass along the discord invite to the hackthon to registrants for them to be able to join.  The hope by inviting them personally, this will reduce bad actors/bots from entering the discord with a combination of disabling invites from any role but the `mod` role. 

### Any new dependencies? Why were they added?

nodemailer for being able to mail