### PR TITLE
Updates mail body and tweaks transport creation

### DIFF
--- a/onboarder.ts
+++ b/onboarder.ts
@@ -21,9 +21,22 @@ const dry_run = program.parse().opts().dryrun;
 const createMailMetaFromRow = (row: any) => {
   return {
     to: row["email"],
-    subject: "Web3Con 2022 Hackathon Discord invite",
-    message: `Hi ${row["discord_handle"]}, thank you for joining the Web3Con 2022 hackathon!  Please use the link below to join the Web3Con discord server:`,
-    inviteLinkHTML: `<div><a href="${DISCORD_INVITE}">${DISCORD_INVITE}</a></div>`
+    subject: "web3con 2022 Hackathon Discord Invite",
+    inviteLinkHTML: `<div>
+                        <p>Hi ${row["discord_handle"]}, thank you for registering for the web3con 2022 hackathon!  Please use the link below to join the web3con discord server:</p>
+                     </div>
+                     <div>
+                        <a href="${DISCORD_INVITE}">${DISCORD_INVITE}</a>
+                     </div>
+                     <div>
+                        <p>If you're experiencing issues joining the server please reply to this email and we'll assist you to as soon as we possibly can.<p/>
+                     </div>
+                     <div>
+                        <div>
+                          <p>Happy hacking!</p>
+                        </div>
+                        <p>-web3con team<p/>
+                     </div>`
   } as MailMeta;
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "commander": "^8.2.0",
     "discord-api-types": "^0.26.1",
     "discord.js": "^13.6.0",
+    "dotenv": "^16.0.0",
     "express": "^4.17.1",
     "fast-csv": "^4.3.6",
     "nodemailer": "^6.7.2",

--- a/src/mailer/mailer.ts
+++ b/src/mailer/mailer.ts
@@ -24,13 +24,19 @@ const mail = async (options: MailMeta) => {
     //     },
     // });
 
-    const FROM_ADDRESS = "aRealEmail@gmail.com";
+    const FROM_ADDRESS = process.env.WEB3CON_EMAIL_USERNAME;
 
+    /**
+     * Note: To use the mailer locally on your machine with a gmail account, you must first enable the "less secure app" toggle in your account
+     * by visiting https://myaccount.google.com/lesssecureapps and flipping the switch.  This technique is only recommended for users running this script
+     * locally on their machines and is not intended to be run in a production environment
+     */
     const transporter = nodemailer.createTransport({
-        service: 'gmail',
+        host: "smtp.gmail.com",
+        port: 587,
         auth: {
           user: FROM_ADDRESS,
-          pass: process.env.EMAIL_PASSWORD
+          pass: process.env.WEB3CON_EMAIL_PASSWORD
         }
       });
 
@@ -38,7 +44,6 @@ const mail = async (options: MailMeta) => {
         from: FROM_ADDRESS,
         to: options.to,
         subject: options.subject,
-        text: options.message,
         html: options.inviteLinkHTML
     };
 

--- a/src/types/mailer-types.ts
+++ b/src/types/mailer-types.ts
@@ -1,6 +1,5 @@
 export type MailMeta = {
     to: string,
     subject: string,
-    message: string,
     inviteLinkHTML: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -691,6 +691,11 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
+dotenv@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.0.tgz#c619001253be89ebb638d027b609c75c26e47411"
+  integrity sha512-qD9WU0MPM4SWLPJy/r2Be+2WgQj8plChsyrCNQzW/0WjvcJQiKQJ9mH3ZgB3fxbUUxgc/11ZJ0Fi5KiimWGz2Q==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION

### What does it do?

- updated the mail body after testing the mailer with a actual gmail account
- Left a note about how to configure ones gamil to be able to run the script locally
- removed 'test' type from mailer-types in favour of just utilzing a html body

### Any helpful background information?

This was the final round of tweaks before utilizing this script to mail out the invites to participants

### Any new dependencies? Why were they added?

dotenv